### PR TITLE
Complex string identification and subroutine tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Version 1.1.1
 * Added support for Code Folding via !REGION and !ENDREGION (can also use *REGION and *ENDREGION)
 * Added auto closing pairs for region declarations
 
+Version 1.1.2
+* Added support for SUBROUTINE and CALL SURBOUTINE
+* Highlight lines where control-break logic starts
+* Improve quoted string identification
+
 ## Installation
 Inside VSCode from the command pallet Install Extension -> PickBasic
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Version 1.1.1
 * Added auto closing pairs for region declarations
 
 Version 1.1.2
-* Added support for SUBROUTINE and CALL SURBOUTINE
+* Added support for SUBROUTINE and CALL SUBROUTINE
 * Highlight lines where control-break logic starts
 * Improve quoted string identification
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pick",
 	"displayName": "PickBasic",
 	"description": "Pick Basic Syntax Highlighting and language support",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"publisher": "TravisHaley",
 	"engines": {
 		"vscode": "^1.1.0"

--- a/syntaxes/pick.tmLanguage
+++ b/syntaxes/pick.tmLanguage
@@ -33,13 +33,76 @@
 			<key>comment</key>
 			<string>this will highlight the subroutine keyword and the name of the subroutine seperately</string>
 			<key>match</key>
-			<string>(SUBROUTINE) ([A-Z_-]+)</string>
+			<string>(SUBROUTINE)\s+([A-Z0-9_-]+)</string>
+			<key>name</key>
+			<string>entity.name.function.pick</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.pick</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.pick</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>this will highlight the CALL keyword and the name of the subsequent call seperately</string>
+			<key>match</key>
+			<string>(CALL)\s+([A-Z0-9_\.-]+)</string>
+			<key>name</key>
+			<string>entity.name.function.pick</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.pick</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.pick</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>this will highlight the GOSUB keyword and the subroutine name called</string>
+			<key>match</key>
+			<string>(GOSUB)\s+([A-Z_\.0-9]*)</string>
+			<key>name</key>
+			<string>entity.name.function.pick</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.pick</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.pick</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Highlight lines where control-break logic starts</string>
+			<key>match</key>
+			<string>([A-Z_\.0-9]*)(:)\s*\n</string>
 			<key>name</key>
 			<string>entity.name.function.pick</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(\'[A-Za-z0-9\:\-\_ ]*\'|\"[A-Za-z0-9\:\-\_ ]*\")</string>
+			<string>(\'[A-Za-z0-9()@#\=;:,\\\/|.\-\"\_ ]*\'|\"[A-Za-z0-9()@#\=;:,\\\/|.\-\'\_ ]*\")</string>
 			<key>name</key>
 			<string>string.other.quoted-or-unquoted.pick</string>
 		</dict>
@@ -51,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(=|&lt;|&gt;|==|!=|\bNE\b|\bAND\b|\bEQ\b|\bLT\b|\bGT\b)</string>
+			<string>(=|&lt;|&gt;|==|!=|\bNE\b|\bAND\b|\bEQ\b|\bLT\b|\bGT\b|:|\+)</string>
 			<key>name</key>
 			<string>keyword.operator.pick</string>
 		</dict>

--- a/syntaxes/pick.tmLanguage
+++ b/syntaxes/pick.tmLanguage
@@ -31,9 +31,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>this will highlight the subroutine keyword and the name of the subroutine seperately</string>
+			<string>this will highlight the SUBROUTINE keyword and the name of the subroutine separately</string>
 			<key>match</key>
-			<string>(SUBROUTINE)\s+([A-Z0-9_-]+)</string>
+			<string>(SUBROUTINE)\s+([a-zA-Z0-9_-]+)</string>
 			<key>name</key>
 			<string>entity.name.function.pick</string>
 		</dict>
@@ -52,9 +52,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>this will highlight the CALL keyword and the name of the subsequent call seperately</string>
+			<string>this will highlight the CALL keyword and the name of the subsequent call separately</string>
 			<key>match</key>
-			<string>(CALL)\s+([A-Z0-9_\.-]+)</string>
+			<string>(CALL)\s+([a-zA-Z0-9_\.-]+)</string>
 			<key>name</key>
 			<string>entity.name.function.pick</string>
 		</dict>
@@ -75,7 +75,28 @@
 			<key>comment</key>
 			<string>this will highlight the GOSUB keyword and the subroutine name called</string>
 			<key>match</key>
-			<string>(GOSUB)\s+([A-Z_\.0-9]*)</string>
+			<string>(GOSUB)\s+([a-zA-Z_\.0-9]*)</string>
+			<key>name</key>
+			<string>entity.name.function.pick</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.pick</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.pick</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>this will highlight the GOTO keyword and the subsequent section called</string>
+			<key>match</key>
+			<string>(GOTO)\s+([a-zA-Z_\.0-9]*)</string>
 			<key>name</key>
 			<string>entity.name.function.pick</string>
 		</dict>


### PR DESCRIPTION
Enhancements since jacobbennett's initial version of this syntax for sublime: https://github.com/jordonbrill/sublime-pickbasic

Modified to not change enhancements you have already made.

Properly highlight `SUBROUTINE` calls
Properly highlight control-break logic calls
Identify GOSUB lines better
Cleanup the calling of a subroutine using the `CALL` keyword
Significantly improve the process of identifying strings or quoted characters